### PR TITLE
Enforce Max Auto Prepare for PostgreSQL EF/Dapper

### DIFF
--- a/frameworks/CSharp/aspnetcore/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Benchmarks.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Npgsql" Version="3.2.2" />
+    <PackageReference Include="Npgsql" Version="3.2.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.0-preview1" />
   </ItemGroup>
 </Project>

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/DapperDb.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/DapperDb.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Benchmarks.Configuration;
 using Dapper;
 using Microsoft.Extensions.Options;
+using Npgsql;
 
 namespace Benchmarks.Data
 {
@@ -21,6 +22,14 @@ namespace Benchmarks.Data
 
         public DapperDb(IRandom random, DbProviderFactory dbProviderFactory, IOptions<AppSettings> appSettings)
         {
+            if (appSettings.Value.Database == DatabaseServer.PostgreSql)
+            {
+                var builder = new NpgsqlConnectionStringBuilder(appSettings.Value.ConnectionString);
+                if (builder.MaxAutoPrepare < 20)
+                {
+                    throw new Exception($"{nameof(builder.MaxAutoPrepare)} must be at least 20 in the PostgreSQL connection string");
+                }
+            }
             _random = random;
             _dbProviderFactory = dbProviderFactory;
             _connectionString = appSettings.Value.ConnectionString;

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/EfDb.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/EfDb.cs
@@ -9,6 +9,7 @@ using Benchmarks.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.Options;
+using Npgsql;
 
 namespace Benchmarks.Data
 {
@@ -20,6 +21,14 @@ namespace Benchmarks.Data
 
         public EfDb(IRandom random, ApplicationDbContext dbContext, IOptions<AppSettings> appSettings)
         {
+            if (appSettings.Value.Database == DatabaseServer.PostgreSql)
+            {
+                var builder = new NpgsqlConnectionStringBuilder(dbContext.Database.GetDbConnection().ConnectionString);
+                if (builder.MaxAutoPrepare < 20)
+                {
+                    throw new Exception($"{nameof(builder.MaxAutoPrepare)} must be at least 20 in the PostgreSQL connection string");
+                }
+            }
             _random = random;
             _dbContext = dbContext;
             _useBatchUpdate = appSettings.Value.Database != DatabaseServer.PostgreSql;

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/EfDb.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/EfDb.cs
@@ -17,7 +17,6 @@ namespace Benchmarks.Data
     {
         private readonly IRandom _random;
         private readonly ApplicationDbContext _dbContext;
-        private readonly bool _useBatchUpdate;
 
         public EfDb(IRandom random, ApplicationDbContext dbContext, IOptions<AppSettings> appSettings)
         {
@@ -31,7 +30,6 @@ namespace Benchmarks.Data
             }
             _random = random;
             _dbContext = dbContext;
-            _useBatchUpdate = appSettings.Value.Database != DatabaseServer.PostgreSql;
         }
 
         private static readonly Func<ApplicationDbContext, int, Task<World>> _firstWorldQuery
@@ -75,17 +73,9 @@ namespace Benchmarks.Data
                 _dbContext.Entry(result).Property("RandomNumber").CurrentValue = _random.Next(1, 10001);
 
                 results[i] = result;
-
-                if (!_useBatchUpdate)
-                {
-                    await _dbContext.SaveChangesAsync();
-                }
             }
 
-            if (_useBatchUpdate)
-            {
-                await _dbContext.SaveChangesAsync();
-            }
+            await _dbContext.SaveChangesAsync();
 
             return results;
         }

--- a/frameworks/CSharp/aspnetcore/Benchmarks/appsettings.postgresql.json
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/appsettings.postgresql.json
@@ -1,4 +1,4 @@
 ﻿{
-  "ConnectionString": "Server={db_server_placeholder};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=1024;NoResetOnClose=true",
+  "ConnectionString": "Server={db_server_placeholder};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=1024;Max Auto Prepare=20;NoResetOnClose=true",
   "Database": "postgresql"
 }


### PR DESCRIPTION
@dougbu this is a rebased version of https://github.com/aspnet/FrameworkBenchmarks/pull/4, rebased on master and also including an update of Npgsql to version 3.2.4, fixing the auto-prepare issue you found.

The second commit also enables batching in the Ef scenario for PostgreSQL, as discussed.